### PR TITLE
Updates to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,69 @@
 
 In this repo, you can find artwork in standard formats for the CNCF [projects](https://www.cncf.io/projects/) and programs. We prepare artwork in PNG, SVG and AI formats. Artwork labeled Pantone should only be used in print. Artwork is generally available in horizontal (also known as landscape format), stacked (which is closer to square), and icon (which does not include the name and are square).
 
+<br>
+
+<b>CNCF Project Logos</b>
+
+<img src="https://github.com/alexcontini/artwork/blob/master/kubernetes/horizontal/color/kubernetes-horizontal-noborder-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/alexcontini/artwork/blob/master/kubernetes/stacked/color/kubernetes-stacked-noborder-color.png" width="120" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/alexcontini/artwork/blob/master/kubernetes/icon/color/kubernetes-icon-noborder-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+
+<img src="https://github.com/alexcontini/artwork/blob/master/prometheus/horizontal/color/prometheus-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/alexcontini/artwork/blob/master/prometheus/stacked/color/prometheus-stacked-color.png" width="120" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/alexcontini/artwork/blob/master/prometheus/icon/color/prometheus-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+<img src="https://github.com/alexcontini/artwork/blob/master/opentracing/horizontal/color/opentracing-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;   &nbsp; <img src="https://github.com/alexcontini/artwork/blob/master/opentracing/stacked/color/opentracing-stacked-color.png" width="120" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/alexcontini/artwork/blob/master/opentracing/icon/color/opentracing-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+<img src="https://github.com/alexcontini/artwork/blob/master/fluentd/horizontal/color/fluentd-horizontal-color.png" width="200">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/fluentd/stacked/color/fluentd-stacked-color.png" width="120">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/fluentd/icon/color/fluentd-icon-color.png" width="75">
+
+<img src="https://github.com/cncf/artwork/blob/master/linkerd/horizontal/Color/linkerd-horizontal-color.png" width="200">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/linkerd/stacked/color/linkerd-stacked-color.png" width="110">   &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/linkerd/icon/color/linkerd-icon-color.png" width="80">
+
+<img src="https://github.com/cncf/artwork/blob/master/grpc/horizontal/color/grpc-horizontal-color.png" width="200">      &nbsp;  &nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/grpc/icon/color/grpc-icon-color.png" width="110">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/grpc/icon/color/grpc-icon-color.png" width="110">
+
+<img src="https://github.com/cncf/artwork/blob/master/coredns/horizontal/solid color/core-dns_horizontal-solid-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/coredns/stacked/solid color/core-dns-stacked-solid-color.png" width="120" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/coredns/icon/color/core-dns-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+<img src="https://github.com/cncf/artwork/blob/master/containerd/horizontal/color/containerd-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/containerd/stacked/color/containerd-stacked-color.png" width="95" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/containerd/icon/color/containerd-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+<img src="https://github.com/cncf/artwork/blob/master/rkt/horizontal/color/rkt-horizontal-color.png" width="180" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/rkt/stacked/color/rkt-stacked-color.png" width="95" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/rkt/icon/color/rkt-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+<img src="https://github.com/cncf/artwork/blob/master/cni/horizontal/color/cni-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/cni/stacked/color/cni-stacked-color.png" width="100" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/cni/icon/Color/cni-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+<img src="https://github.com/cncf/artwork/blob/master/envoy/horizontal/color/envoy-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/envoy/stacked/color/envoy-stacked-color.png" width="110" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/envoy/icon/color/envoy-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+<img src="https://github.com/cncf/artwork/blob/master/jaeger/horizontal/color/jaeger-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/jaeger/stacked/color/jaeger-stacked-color.png" width="100" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/jaeger/icon/color/jaeger-icon-color.png" width="90" style="display:inline;vertical-align:middle;padding:2%">
+
+<img src="https://github.com/cncf/artwork/blob/master/notary/horizontal/color/notary-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/notary/stacked/color/notary-stacked-color.png" width="90" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/notary/icon/color/notary-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+<img src="https://github.com/cncf/artwork/blob/master/tuf/horizontal/color/tuf-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/tuf/stacked/color/tuf-stacked-color.png" width="110" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/tuf/icon/color/tuf-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
+
+<br>
+
 We also include logos for the [CNCF](https://github.com/cncf/artwork/tree/master/cncf/horizontal/color), Certified Kubernetes Administrators ([CKA](https://github.com/cncf/artwork/tree/master/other/cka/color)), Kubernetes Certified Service Providers ([KCSP](https://github.com/cncf/artwork/tree/master/other/kcsp/color)), CNCF [Ambassadors](https://github.com/cncf/artwork/tree/master/other/ambassador/stacked/color) and KubeCon and CloudNativeCon ([KCCNC](https://github.com/cncf/artwork/tree/master/other/kubecon-cloudnativecon/na-2018/color)).
+
+<br>
+<b>Other CNCF Logos</b>
+
+<img src="https://github.com/cncf/artwork/blob/master/cncf/horizontal/color/cncf-color.png" width="210">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/other/cka/color/kubernetes-cka-color.png" width="160">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/other/kcsp/color/kubernetes-kcsp-color.png" width="160">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/other/ambassador/horizontal/color/cncf-ambassador-colour-horizontal.png" width="235">
+
+
+<img src="https://github.com/cncf/artwork/blob/master/other/kubecon-cloudnativecon/eu-2018/color/kccnc-eu-color.png" width="260">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/other/kubecon-cloudnativecon/china-2018/color/kccnc-china-color.png" width="260">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/other/kubecon-cloudnativecon/na-2018/color/kccnc-na-color.png" width="260">
+
+<img src="https://github.com/cncf/artwork/blob/master/kubernetes/certified-kubernetes/1.9/color/certified_kubernetes_1.9_color.png" width="130">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/kubernetes/certified-kubernetes/versionless/color/certified_kubernetes_color.png" width="130">
+
+<img src="https://github.com/cncf/artwork/blob/master/other/devstats/horizontal/color/devstats-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/other/devstats/stacked/color/devstats-stacked-color.png" width="110" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/other/devstats/icon/color/devstats-icon-color.png" width="95" style="display:inline;vertical-align:middle;padding:2%">
+
+
+<img src="https://github.com/cncf/artwork/blob/master/other/illustrations/ashley-mcnamara/original/cncf-cloud-gophers.png" width="400">
+
+
 
 Use of any trademark or logo is subject to the trademark policy available at https://www.linuxfoundation.org/trademark-usage
 
 The [Certified Kubernetes](https://github.com/cncf/artwork/tree/master/kubernetes/certified-kubernetes) marks are only available for use with [conformant](https://www.cncf.io/certification/software-conformance/) platforms and distributions and must comply with the [brand guidelines](https://github.com/cncf/artwork/tree/master/kubernetes/certified-kubernetes/certified-kubernetes-brand-guide.pdf).
 
 Questions? Please email [info@cncf.io](mailto:info@cncf.io).
+
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 In this repo, you can find artwork in standard formats for the CNCF [projects](https://www.cncf.io/projects/) and programs. We prepare artwork in PNG, SVG and AI formats. Artwork labeled Pantone should only be used in print. Artwork is generally available in horizontal (also known as landscape format), stacked (which is closer to square), and icon (which does not include the name and are square).
 
-<br>
-
-<b>CNCF Project Logos</b>
+## CNCF Project Logos
 
 <img src="https://github.com/alexcontini/artwork/blob/master/kubernetes/horizontal/color/kubernetes-horizontal-noborder-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/alexcontini/artwork/blob/master/kubernetes/stacked/color/kubernetes-stacked-noborder-color.png" width="120" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/alexcontini/artwork/blob/master/kubernetes/icon/color/kubernetes-icon-noborder-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
 
@@ -35,12 +33,9 @@ In this repo, you can find artwork in standard formats for the CNCF [projects](h
 
 <img src="https://github.com/cncf/artwork/blob/master/tuf/horizontal/color/tuf-horizontal-color.png" width="200" style="display:inline;vertical-align:middle;padding:2%">      &nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/tuf/stacked/color/tuf-stacked-color.png" width="110" style="display:inline;vertical-align:middle;padding:2%">&nbsp;  &nbsp;  &nbsp; <img src="https://github.com/cncf/artwork/blob/master/tuf/icon/color/tuf-icon-color.png" width="75" style="display:inline;vertical-align:middle;padding:2%">
 
-<br>
+## Other CNCF Logos
 
 We also include logos for the [CNCF](https://github.com/cncf/artwork/tree/master/cncf/horizontal/color), Certified Kubernetes Administrators ([CKA](https://github.com/cncf/artwork/tree/master/other/cka/color)), Kubernetes Certified Service Providers ([KCSP](https://github.com/cncf/artwork/tree/master/other/kcsp/color)), CNCF [Ambassadors](https://github.com/cncf/artwork/tree/master/other/ambassador/stacked/color) and KubeCon and CloudNativeCon ([KCCNC](https://github.com/cncf/artwork/tree/master/other/kubecon-cloudnativecon/na-2018/color)).
-
-<br>
-<b>Other CNCF Logos</b>
 
 <img src="https://github.com/cncf/artwork/blob/master/cncf/horizontal/color/cncf-color.png" width="210">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/other/cka/color/kubernetes-cka-color.png" width="160">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/other/kcsp/color/kubernetes-kcsp-color.png" width="160">&nbsp;  &nbsp;  <img src="https://github.com/cncf/artwork/blob/master/other/ambassador/horizontal/color/cncf-ambassador-colour-horizontal.png" width="235">
 


### PR DESCRIPTION
Added a GRPC icon, all three KubeCon + CloudNativeCon 2018 logos (EU, China and NA), Certified Kubernetes marks (without a version and 1.9), devstats logos, and cloud gopher logo without transparency. Also added subheaders for "CNCF Project Logos" and "Other CNCF Logos".