### PR TITLE
Adding missing tag to close table

### DIFF
--- a/examples/sandbox.md
+++ b/examples/sandbox.md
@@ -1609,7 +1609,7 @@
         <td><img src="/projects/openservicemesh/stacked/white/openservicemesh-stacked-white.svg" width="95"></td>
         <td><img src="/projects/openservicemesh/icon/white/openservicemesh-icon-white.svg" width="75"></td>
     </tr>
-
+</table>
     
 #### metal3 Logos
 


### PR DESCRIPTION
Thanks for merging https://github.com/cncf/artwork/pull/193, @caniszczyk - sorry I didn't notice this remaining issue. This should fix the on-page display now (moving the logos above the next title): https://github.com/cncf/artwork/blob/master/examples/sandbox.md#open-service-mesh-logos

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>