### PR TITLE
k8gb: Remove xml declarations from the beginning of the svg images

### DIFF
--- a/projects/k8gb/horizontal/color/k8gb-horizontal-color.svg
+++ b/projects/k8gb/horizontal/color/k8gb-horizontal-color.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 234.3 101.6" style="enable-background:new 0 0 234.3 101.6;" xml:space="preserve">
 <style type="text/css">

--- a/projects/k8gb/icon/color/k8gb-icon-color.svg
+++ b/projects/k8gb/icon/color/k8gb-icon-color.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 104.1 101.6" style="enable-background:new 0 0 104.1 101.6;" xml:space="preserve">
 <style type="text/css">

--- a/projects/k8gb/stacked/black/k8gb-stacked-black.svg
+++ b/projects/k8gb/stacked/black/k8gb-stacked-black.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 118.7 163.7" style="enable-background:new 0 0 118.7 163.7;" xml:space="preserve">
 <path d="M61,39.9c-0.1-0.1-0.1-0.2-0.1-0.3V24.3c0-0.1,0.1-0.2,0.1-0.3c0.1-0.1,0.2-0.1,0.3-0.1h0.1c4.9,1.1,9.3,6.3,11.9,13.9

--- a/projects/k8gb/stacked/color/k8gb-stacked-color.svg
+++ b/projects/k8gb/stacked/color/k8gb-stacked-color.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 118.7 163.7" style="enable-background:new 0 0 118.7 163.7;" xml:space="preserve">
 <style type="text/css">

--- a/projects/k8gb/stacked/white/k8gb-stacked-white.svg
+++ b/projects/k8gb/stacked/white/k8gb-stacked-white.svg
@@ -1,5 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 118.7 163.7" style="enable-background:new 0 0 118.7 163.7;" xml:space="preserve">
 <style type="text/css">


### PR DESCRIPTION
Even though the files can be opened and displayed in browser/graphical editor, the xml declaration at the beginning of the file blocks some other tools to properly identify the mime type of the file.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>