### PR TITLE
Update Keptn logos

### DIFF
--- a/examples/incubating.md
+++ b/examples/incubating.md
@@ -1098,6 +1098,55 @@
     </tr>
 </table>
 
+#### Keptn Logos
+
+<table>
+    <tr>
+        <th colspan="7"></th>
+    </tr>
+    <tr>
+        <th></th>
+        <th colspan="3">PNG</th>
+        <th colspan="3">SVG</th>
+    </tr>
+    <tr>
+        <th></th>
+        <th>horizontal</th>
+        <th>stacked</th>
+        <th>icon</th>
+        <th>horizontal</th>
+        <th>stacked</th>
+        <th>icon</th>
+    </tr>
+    <tr>
+        <th>color</th>
+        <td><img src="/projects/keptn/horizontal/color/keptn-horizontal-color.png" width="200"></td>
+        <td><img src="/projects/keptn/stacked/color/keptn-stacked-color.png" width="95"></td>
+        <td><img src="/projects/keptn/icon/color/keptn-icon-color.png" width="75"></td>
+        <td><img src="/projects/keptn/horizontal/color/keptn-horizontal-color.svg" width="200"></td>
+        <td><img src="/projects/keptn/stacked/color/keptn-stacked-color.svg" width="95"></td>
+        <td><img src="/projects/keptn/icon/color/keptn-icon-color.svg" width="75"></td>
+    </tr>
+   <tr>
+        <th>black</th>
+        <td><img src="/projects/keptn/horizontal/black/keptn-horizontal-black.png" width="200"></td>
+        <td><img src="/projects/keptn/stacked/black/keptn-stacked-black.png" width="95"></td>
+        <td><img src="/projects/keptn/icon/black/keptn-icon-black.png" width="75"></td>
+        <td><img src="/projects/keptn/horizontal/black/keptn-horizontal-black.svg" width="200"></td>
+        <td><img src="/projects/keptn/stacked/black/keptn-stacked-black.svg" width="95"></td>
+        <td><img src="/projects/keptn/icon/black/keptn-icon-black.svg" width="75"></td>
+    </tr>
+    <tr>
+        <th>white</th>
+        <td><img src="/projects/keptn/horizontal/white/keptn-horizontal-white.png" width="200"></td>
+        <td><img src="/projects/keptn/stacked/white/keptn-stacked-white.png" width="95"></td>
+        <td><img src="/projects/keptn/icon/white/keptn-icon-white.png" width="75"></td>
+        <td><img src="/projects/keptn/horizontal/white/keptn-horizontal-white.svg" width="200"></td>
+        <td><img src="/projects/keptn/stacked/white/keptn-stacked-white.svg" width="95"></td>
+        <td><img src="/projects/keptn/icon/white/keptn-icon-white.svg" width="75"></td>
+    </tr>
+</table>
+
 Use of any trademark or logo is subject to the trademark policy available at https://www.linuxfoundation.org/trademark-usage
 
 Questions? Please email [info@cncf.io](mailto:info@cncf.io).

--- a/examples/sandbox.md
+++ b/examples/sandbox.md
@@ -1530,56 +1530,6 @@
     </tr>
     </table>
 
-
-#### Keptn Logos
-
-<table>
-    <tr>
-        <th colspan="7"></th>
-    </tr>
-    <tr>
-        <th></th>
-        <th colspan="3">PNG</th>
-        <th colspan="3">SVG</th>
-    </tr>
-    <tr>
-        <th></th>
-        <th>horizontal</th>
-        <th>stacked</th>
-        <th>icon</th>
-        <th>horizontal</th>
-        <th>stacked</th>
-        <th>icon</th>
-    </tr>
-    <tr>
-        <th>color</th>
-        <td><img src="/projects/keptn/horizontal/color/keptn-horizontal-color.png" width="200"></td>
-        <td><img src="/projects/keptn/stacked/color/keptn-stacked-color.png" width="95"></td>
-        <td><img src="/projects/keptn/icon/color/keptn-icon-color.png" width="75"></td>
-        <td><img src="/projects/keptn/horizontal/color/keptn-horizontal-color.svg" width="200"></td>
-        <td><img src="/projects/keptn/stacked/color/keptn-stacked-color.svg" width="95"></td>
-        <td><img src="/projects/keptn/icon/color/keptn-icon-color.svg" width="75"></td>
-    </tr>
-   <tr>
-        <th>black</th>
-        <td><img src="/projects/keptn/horizontal/black/keptn-horizontal-black.png" width="200"></td>
-        <td><img src="/projects/keptn/stacked/black/keptn-stacked-black.png" width="95"></td>
-        <td><img src="/projects/keptn/icon/black/keptn-icon-black.png" width="75"></td>
-        <td><img src="/projects/keptn/horizontal/black/keptn-horizontal-black.svg" width="200"></td>
-        <td><img src="/projects/keptn/stacked/black/keptn-stacked-black.svg" width="95"></td>
-        <td><img src="/projects/keptn/icon/black/keptn-icon-black.svg" width="75"></td>
-    </tr>
-    <tr>
-        <th>white</th>
-        <td><img src="/projects/keptn/horizontal/white/keptn-horizontal-white.png" width="200"></td>
-        <td><img src="/projects/keptn/stacked/white/keptn-stacked-white.png" width="95"></td>
-        <td><img src="/projects/keptn/icon/white/keptn-icon-white.png" width="75"></td>
-        <td><img src="/projects/keptn/horizontal/white/keptn-horizontal-white.svg" width="200"></td>
-        <td><img src="/projects/keptn/stacked/white/keptn-stacked-white.svg" width="95"></td>
-        <td><img src="/projects/keptn/icon/white/keptn-icon-white.svg" width="75"></td>
-    </tr>
-    </table>
-
 #### Kuma Logos
 
 <table>


### PR DESCRIPTION
[On 2022-07-13](https://www.cncf.io/blog/2022/07/13/toc-votes-to-advance-keptn-to-the-cncf-incubator/), Keptn moved to the incubating status. This PR moves the logos into the right file. 