### PR TITLE
Fix table of Cert-Manager Logos

### DIFF
--- a/examples/graduated.md
+++ b/examples/graduated.md
@@ -56,12 +56,12 @@ displayed on the light grey of tables.*
 
 <table>
     <tr>
-        <th colspan="7"></th>
+        <th colspan="5"></th>
     </tr>
     <tr>
         <th></th>
-        <th colspan="3">PNG</th>
-        <th colspan="3">SVG</th>
+        <th colspan="2">PNG</th>
+        <th colspan="2">SVG</th>
     </tr>
     <tr>
         <th></th>


### PR DESCRIPTION
### Description

The SVG logos of Cert-Manager are displayed in the wrong section on its table due to the wrong `colspan` value. This PR provides a fix.

Previous: 
<img width="659" alt="image" src="https://github.com/user-attachments/assets/adddf8a4-1569-4380-804a-c57621a14942" />

After fix: 

<img width="631" alt="image" src="https://github.com/user-attachments/assets/2d5fa231-2c2c-4fd4-8a50-8293f4b34a5a" />
