### PR TITLE
fix: OAuth2-Proxy project -> OAuth2 Proxy

### DIFF
--- a/examples/sandbox_l-r.md
+++ b/examples/sandbox_l-r.md
@@ -372,7 +372,7 @@
     </tr>
 </table>
 
-#### OAuth2-Proxy Logos
+#### OAuth2 Proxy Logos
 
 <table>
     <tr>


### PR DESCRIPTION
@nate-double-u during a discussion for the contribution agreement we decided to ensure the name of the project is properly written down everywhere. Which is why I decided change it here as well. From `OAuth2-Proxy` to `OAuth2 Proxy`